### PR TITLE
Fix type when passing into signature service

### DIFF
--- a/src/DigitalSignature/Signature.php
+++ b/src/DigitalSignature/Signature.php
@@ -28,7 +28,7 @@ class Signature {
         if ($contains_body === true) {
             $headers["Content-Digest"] = $this->signatureService->generateContentDigest($body, $this->signatureConfig);
         }
-        $timestamp = time();
+        $timestamp = (string) time();
         $headers["x-ebay-signature-key"] = $this->signatureService->generateSignatureKey($this->signatureConfig);
         $headers["Signature-Input"] = $this->signatureService->generateSignatureInput($contains_body, $timestamp, $this->signatureConfig);
         $headers["Signature"] = $this->signatureService->generateSignature($contains_body, $headers, $method, $endpoint, $timestamp, $this->signatureConfig);


### PR DESCRIPTION
$timestamp passed into $this->signatureService->generateSignatureInput method requires to be a string. 

Adding declare(strict_types=1); on top of the file would highlight the issue. Let me know if you are interested in adding declare(strict_types=1); to all files 

Let me know if I need to create an issue for this to be linked. 